### PR TITLE
Run camera independently of state changes

### DIFF
--- a/payload/constants.py
+++ b/payload/constants.py
@@ -59,6 +59,14 @@ PROJECT_DIRECTORY_NAME = "Payload-2024-2025"
 
 CAMERA_SAVE_PATH = Path("logs/video.h264")
 
+CAMERA_START_RECORDING_TIMEOUT = 2 * 60
+"""The amount of time in seconds that the camera waits for the motor burn to start before it starts
+recording anyway. This is here because the IMU may not work."""
+
+CAMERA_STOP_RECORDING_TIMEOUT = 30 * 60
+"""The maximum amount of time in seconds that the camera waits for the rocket to land before it
+stops recording. This is here because the IMU or some other part of the code may not work."""
+
 # -------------------------------------------------------
 # Logging Configuration
 # -------------------------------------------------------

--- a/payload/hardware/camera.py
+++ b/payload/hardware/camera.py
@@ -4,7 +4,11 @@ import os
 from contextlib import suppress
 from threading import Event, Thread
 
-from payload.constants import CAMERA_SAVE_PATH, CAMERA_START_RECORDING_TIMEOUT, CAMERA_STOP_RECORDING_TIMEOUT
+from payload.constants import (
+    CAMERA_SAVE_PATH,
+    CAMERA_START_RECORDING_TIMEOUT,
+    CAMERA_STOP_RECORDING_TIMEOUT,
+)
 
 # These libraries are only available on the Raspberry Pi so we ignore them if they are not available
 with suppress(ImportError):

--- a/payload/hardware/camera.py
+++ b/payload/hardware/camera.py
@@ -4,7 +4,7 @@ import os
 from contextlib import suppress
 from threading import Event, Thread
 
-from payload.constants import CAMERA_SAVE_PATH
+from payload.constants import CAMERA_SAVE_PATH, CAMERA_START_RECORDING_TIMEOUT, CAMERA_STOP_RECORDING_TIMEOUT
 
 # These libraries are only available on the Raspberry Pi so we ignore them if they are not available
 with suppress(ImportError):
@@ -68,12 +68,12 @@ class Camera:
         # Check if motor burn has started, if it has, we can stop buffering and start saving
         # the video. This way we get a few seconds of video before liftoff too. Otherwise, just
         # sleep and wait.
-        self.motor_burn_started.wait()
+        self.motor_burn_started.wait(timeout=CAMERA_START_RECORDING_TIMEOUT)
 
         output.fileoutput = CAMERA_SAVE_PATH
         output.start()
 
         # Keep recording until we have landed:
-        self.stop_context_event.wait()
+        self.stop_context_event.wait(timeout=CAMERA_STOP_RECORDING_TIMEOUT)
 
         output.stop()

--- a/payload/hardware/transmitter.py
+++ b/payload/hardware/transmitter.py
@@ -11,7 +11,7 @@ from payload.interfaces.base_transmitter import BaseTransmitter
 try:
     # TODO: convert this to gpiozero, also go through and organize methods
     from RPi import GPIO
-except ImportError:
+except (ImportError, RuntimeError):
     pass
 
 from payload.data_handling.packets.transmitter_data_packet import TransmitterDataPacket


### PR DESCRIPTION
Adds timeouts to the camera recording, so we should get footage even if the IMU gives up or some random thing fails somewhere else. But it still won't work if the main loop has an exception, in which case the camera will stop recording.