### PR TITLE
Force flushing of file to prevent data loss

### DIFF
--- a/payload/constants.py
+++ b/payload/constants.py
@@ -76,6 +76,10 @@ STOP_SIGNAL = "STOP"
 """The signal to stop the logging and the apogee prediction process, this will be put in the queue
 to stop the process"""
 
+NUMBER_OF_LINES_TO_LOG_BEFORE_FLUSHING = 10
+"""The number of lines to log before flushing the data to the file, this is to prevent data loss in
+case of a crash or a reboot."""
+
 # -------------------------------------------------------
 # State Machine Configuration
 # -------------------------------------------------------

--- a/payload/mock/display.py
+++ b/payload/mock/display.py
@@ -137,7 +137,7 @@ class FlightDisplay:
             f"Launch time:               {G}T+{time.strftime('%M:%S', time.gmtime(time_since_launch))}{RESET}",  # noqa: E501
             f"State:                     {G}{self._payload.state.name:<15}{RESET}",
             f"Current Altitude:          {G}{data_processor.current_altitude:<10.2f}{RESET} {R}m{RESET}",  # noqa: E501
-            f"Maximum Altitude:          {G}{data_processor.max_altitude:<10.2f}{RESET} {R}m/s{RESET}",  # noqa: E501
+            f"Maximum Altitude:          {G}{data_processor.max_altitude:<10.2f}{RESET} {R}m{RESET}",  # noqa: E501
             f"Current Velocity:          {G}{data_processor.velocity_moving_average:<10.2f}{RESET} {R}m/s{RESET}",  # noqa: E501
             f"Maximum Velocity:          {G}{data_processor.max_vertical_velocity:<10.2f}{RESET} {R}m/s{RESET}",  # noqa: E501
             f"Crew survivability:        {G}{100 * data_processor._crew_survivability:<10.2f}{RESET} {R}%{RESET}",  # noqa: E501


### PR DESCRIPTION
We lost a little bit of LandedState (possibly) in Pelicanator flight 2.

This PR does the same as https://github.com/NCSU-High-Powered-Rocketry-Club/AirbrakesV2/pull/172. Which will eliminate the possibility of losing data. Airbrakes code recorded all data perfectly.